### PR TITLE
Catch and handle error thrown from IsAzeriteEmpoweredItem()

### DIFF
--- a/OutfitterInventory.lua
+++ b/OutfitterInventory.lua
@@ -501,7 +501,8 @@ function Outfitter:GetSlotIDItemInfo(slotID)
 end
 
 function Outfitter:GetAzeriteCodesForLocation(location)
-	if not C_AzeriteEmpoweredItem.IsAzeriteEmpoweredItem(location) then
+	local success,isAzeriteItem  = pcall( function() return C_AzeriteEmpoweredItem.IsAzeriteEmpoweredItem(location) end );
+	if not (success and isAzeriteItem) then
 		return
 	end
 


### PR DESCRIPTION
on 8.3.0 C_AzeriteEmpoweredItem.IsAzeriteEmpoweredItem() is throwing an error. Wrapped the call to  C_AzeriteEmpoweredItem.IsAzeriteEmpoweredItem() with pcall to catch and handle the error.